### PR TITLE
Create REPL Mode

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -218,6 +218,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctrlc"
+version = "3.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "697b5419f348fd5ae2478e8018cb016c00a5881c7f46c717de98ffd135a5651c"
+dependencies = [
+ "nix",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -390,6 +400,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "crossterm",
+ "ctrlc",
  "itertools",
  "lalrpop",
  "lalrpop-util",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ authors = ["Bryan McClain <bamcclain10@gmail.com>"]
 [dependencies]
 clap = { version = "4.5.34", features = ["derive"] }
 crossterm = "0.28.1"
+ctrlc = "3.4.6"
 itertools = "0.14.0"
 lalrpop-util = { version = "0.22.1", features = ["lexer", "unicode"] }
 num-traits = "0.2.19"

--- a/README.md
+++ b/README.md
@@ -64,6 +64,25 @@ The code file is interpreted as a sequence of either assignments (`identifier = 
 
 <br />
 
+## Repl
+
+Rusty Lambda has a build-in Read-Evaluate-Print-Loop (REPL). You can enter expressions line-by-line and see immediate results.
+
+Built-in REPL commands:
+
+- `:all` - Print all named variables
+- `:exit` - Exit the REPL
+- `:help` - Print the help message
+- `:load <file>` - Load and run a code file
+- `:print <expr>` - Print an expression without evaluating it
+- `:steps on` - Print reduction steps to stderr
+- `:steps off` - Don't print reduction steps
+
+You can press Ctrl+C to abort evaluating the current expression.
+Press Ctrl+D or type `:exit` to exit the REPL.
+
+<br />
+
 ## Basic Usage
 
 **Interactive REPL:**

--- a/src/command/executor.rs
+++ b/src/command/executor.rs
@@ -1,7 +1,11 @@
-use std::cell::RefCell;
+use std::cell::{Ref, RefCell};
+use std::collections::{self, BTreeMap};
 use std::num::NonZero;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::{collections::HashMap, error::Error};
+use std::{
+  collections::{HashMap, btree_map},
+  error::Error,
+};
 
 use crate::expr::{Allocator, ExprRef, ExprVisitor, UnpackedExpr};
 use crate::lambda::{ProgramParser, StatementParser};
@@ -9,7 +13,7 @@ use crate::symbol_table::SymbolTable;
 
 pub struct Executor<'s> {
   assign_allocator: Allocator,
-  globals: RefCell<HashMap<&'s str, ExprRef<'s>>>,
+  globals: RefCell<BTreeMap<&'s str, ExprRef<'s>>>,
   numbers: RefCell<Vec<ExprRef<'s>>>,
   program_parser: ProgramParser,
   statement_parser: StatementParser,
@@ -19,7 +23,7 @@ impl<'s> Executor<'s> {
   pub fn new() -> Self {
     Self {
       assign_allocator: Allocator::new(),
-      globals: RefCell::new(HashMap::new()),
+      globals: RefCell::new(BTreeMap::new()),
       numbers: RefCell::new(Vec::new()),
       program_parser: ProgramParser::new(),
       statement_parser: StatementParser::new(),
@@ -30,6 +34,11 @@ impl<'s> Executor<'s> {
   #[allow(unused)]
   pub fn get_global(&self, name: &str) -> Option<ExprRef<'s>> {
     self.globals.borrow().get(name).cloned()
+  }
+
+  #[inline]
+  pub fn all_globals(&self) -> &RefCell<BTreeMap<&'s str, ExprRef<'s>>> {
+    &self.globals
   }
 
   /// Load a code file and return any statements that might need to be evaluated.

--- a/src/command/executor.rs
+++ b/src/command/executor.rs
@@ -1,11 +1,8 @@
-use std::cell::{Ref, RefCell};
-use std::collections::{self, BTreeMap};
+use std::cell::RefCell;
+use std::collections::{BTreeMap, HashMap};
+use std::error::Error;
 use std::num::NonZero;
 use std::sync::atomic::{AtomicBool, Ordering};
-use std::{
-  collections::{HashMap, btree_map},
-  error::Error,
-};
 
 use crate::expr::{Allocator, ExprRef, ExprVisitor, UnpackedExpr};
 use crate::lambda::{EvalExpressionParser as ExpressionParser, ProgramParser, StatementParser};

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -25,8 +25,6 @@ pub struct RunArgs {
   files: Vec<PathBuf>,
 }
 
-static ABORT_EXECUTION: AtomicBool = AtomicBool::new(false);
-
 impl RunArgs {
   pub fn execute(self) -> super::CommandResult {
     let text_data = Arena::new();
@@ -56,30 +54,64 @@ impl RunArgs {
       return Ok(());
     }
 
+    Repl::new(&text_data, &executor, self.steps).run()
+  }
+}
+
+struct Repl<'text, 'assign>
+where
+  'text: 'assign,
+{
+  text_data: &'text Arena<String>,
+  executor: &'assign Executor<'assign>,
+  show_steps: bool,
+  abort: &'static AtomicBool,
+}
+
+impl<'text, 'assign> Repl<'text, 'assign>
+where
+  'text: 'assign,
+{
+  pub fn new(text_data: &'text Arena<String>, executor: &'assign Executor<'assign>, show_steps: bool) -> Self {
+    static ABORT_EXECUTION: AtomicBool = AtomicBool::new(false);
+
+    Self {
+      text_data,
+      executor,
+      show_steps,
+      abort: &ABORT_EXECUTION,
+    }
+  }
+
+  pub fn run(mut self) -> super::CommandResult {
+    // Initialize the Ctrl+C handler
     if let Err(e) = ctrlc::set_handler(|| {
-      ABORT_EXECUTION.store(true, Ordering::Relaxed);
+      self.abort.store(true, Ordering::Relaxed);
     }) {
       eprint!("{}failed to set Ctrl+C handler: {}", "Warning: ".yellow(), e);
     }
 
+    // Set up REPL editor
     let mut editor = DefaultEditor::new()?;
     editor.set_auto_add_history(true);
 
-    let mut should_exit = false;
+    // We only want to exit if Ctrl+C pressed twice in a row
+    let mut ctrl_c_should_exit = false;
+
     loop {
       let line = match editor.readline("> ") {
         Ok(line) => {
-          should_exit = false;
+          ctrl_c_should_exit = false;
           line
         },
 
         Err(ReadlineError::Eof) => return Ok(()),
         Err(ReadlineError::Interrupted) => {
-          if should_exit {
+          if ctrl_c_should_exit {
             return Ok(());
           }
 
-          should_exit = true;
+          ctrl_c_should_exit = true;
           println!("(To exit, press Ctrl+C again or Ctrl+D or type :exit)");
           continue;
         },
@@ -88,24 +120,69 @@ impl RunArgs {
       };
 
       if line.trim().is_empty() {
-        continue;
+        continue; // Skip empty lines
       }
 
-      let line = text_data.alloc(line);
-      let eval_allocator = Allocator::new();
-      match executor.load_statement(&eval_allocator, line.as_str()) {
-        Ok(None) => {},
-        Ok(Some(expr)) => {
-          ABORT_EXECUTION.store(false, Ordering::Relaxed);
+      self.run_line(line);
+    }
+  }
 
-          let result = executor.evaluate_with_abort(&eval_allocator, expr, self.steps, &ABORT_EXECUTION);
-          match result {
-            None => println!("Interrupted"),
-            Some(result) => println!("{result:#}"),
-          }
-        },
-        Err(e) => println!("{e}"),
-      }
+  fn run_line(&mut self, line: String) {
+    // Check for built-in commands
+    let mut command_parts = line.split_whitespace();
+    match command_parts.next() {
+      Some(":h" | ":he" | ":hel" | ":help") => return self.print_help(),
+      Some(":s" | ":st" | ":ste" | ":step" | ":steps") => return self.set_steps(&line, command_parts.collect()),
+
+      // Unknown commands
+      None => {},
+      Some(_) => {},
+    }
+
+    // Not a built-in command, so run the line as code
+    let line = self.text_data.alloc(line);
+    let eval_allocator = Allocator::new();
+    match self.executor.load_statement(&eval_allocator, line.as_str()) {
+      Ok(None) => {},
+      Ok(Some(expr)) => {
+        self.abort.store(false, Ordering::Relaxed);
+
+        let result = self
+          .executor
+          .evaluate_with_abort(&eval_allocator, expr, self.show_steps, &self.abort);
+
+        match result {
+          None => println!("Interrupted"),
+          Some(result) => println!("{result:#}"),
+        }
+      },
+      Err(e) => println!("{e}"),
+    }
+  }
+
+  fn print_help(&self) {}
+
+  fn set_steps(&mut self, line: &str, args: Vec<&str>) {
+    match args.first().cloned() {
+      None => {
+        if self.show_steps {
+          println!("Reduction steps are {}", "on".green());
+        } else {
+          println!("Reduction steps are {}", "off".red());
+        }
+      },
+
+      Some("on" | "1" | "true") if args.len() == 1 => self.show_steps = true,
+
+      Some("off" | "0" | "false") if args.len() == 1 => self.show_steps = false,
+
+      Some(_) => {
+        println!(
+          "Expecting either '{}' or '{}', given '{line}'",
+          ":steps on".white().bold(),
+          ":steps off".white().bold(),
+        )
+      },
     }
   }
 }

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -243,7 +243,7 @@ where
 
         let result = self
           .executor
-          .evaluate_with_abort(&eval_allocator, expr, self.show_steps, &self.abort);
+          .evaluate_with_abort(&eval_allocator, expr, self.show_steps, self.abort);
 
         match result {
           None => println!("Interrupted"),
@@ -270,7 +270,7 @@ where
 
         let result = self
           .executor
-          .evaluate_with_abort(&eval_allocator, expr, self.show_steps, &self.abort);
+          .evaluate_with_abort(&eval_allocator, expr, self.show_steps, self.abort);
 
         match result {
           None => println!("Interrupted"),

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -133,6 +133,7 @@ where
     match command_parts.next() {
       Some(":h" | ":he" | ":hel" | ":help") => return self.print_help(),
       Some(":s" | ":st" | ":ste" | ":step" | ":steps") => return self.set_steps(&line, command_parts.collect()),
+      Some(":a" | ":al" | ":all") => return self.print_all_globals(&line, command_parts.collect()),
 
       // Unknown commands
       None => {},
@@ -183,6 +184,23 @@ where
           ":steps off".white().bold(),
         )
       },
+    }
+  }
+
+  fn print_all_globals(&self, line: &str, args: Vec<&str>) {
+    if !args.is_empty() {
+      println!("Expecting '{}', given '{line}'", ":all".white().bold(),);
+      return;
+    }
+
+    let all_globals = self.executor.all_globals().borrow();
+
+    let max_name_length = all_globals.keys().map(|name| (*name).len()).max().unwrap_or(1);
+    for (name, value) in all_globals.iter() {
+      println!(
+        "{} = {value:#}",
+        format!("{name: <width$}", width = max_name_length).white().bold(),
+      );
     }
   }
 }

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -145,7 +145,7 @@ where
       Some(":e" | ":ex" | ":exi" | ":exit") => return RunLineAction::Exit,
       Some(":h" | ":he" | ":hel" | ":help") => self.print_help(),
       Some(":s" | ":st" | ":ste" | ":step" | ":steps") => self.set_steps(&line, command_parts.collect()),
-      Some(":a" | ":al" | ":all") => self.print_all_globals(&line, command_parts.collect()),
+      Some(":a" | ":al" | ":all") => self.print_all_globals(),
       Some(prefix @ (":p" | ":pr" | ":pri" | ":prin" | ":print")) => {
         self.print_expression(strip_prefix(&line, prefix).to_string())
       },
@@ -203,12 +203,7 @@ where
     }
   }
 
-  fn print_all_globals(&self, line: &str, args: Vec<&str>) {
-    if !args.is_empty() {
-      println!("Expecting '{}', given '{line}'", ":all".white().bold());
-      return;
-    }
-
+  fn print_all_globals(&self) {
     let all_globals = self.executor.all_globals().borrow();
 
     let max_name_length = all_globals.keys().map(|name| (*name).len()).max().unwrap_or(1);

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -93,7 +93,8 @@ where
     if let Err(e) = ctrlc::set_handler(|| {
       self.abort.store(true, Ordering::Relaxed);
     }) {
-      println!("{}failed to set Ctrl+C handler: {}", "Warning: ".yellow(), e);
+      println!("{}: failed to set Ctrl+C handler", "Warning".yellow());
+      println!("{e}\n");
     }
 
     // Set up REPL editor
@@ -137,7 +138,6 @@ where
     }
   }
 
-  // Return `true` to exit the program
   fn run_line(&mut self, line: String) -> RunLineAction {
     // Check for built-in commands
     let mut command_parts = line.split_whitespace();

--- a/src/command/run.rs
+++ b/src/command/run.rs
@@ -166,7 +166,7 @@ where
       (":load <file>", "Load and run a code file"),
       (":print <expr>", "Print an expression without evaluating it"),
       (":steps on", "Print reduction steps to stderr"),
-      (":steps off", "Don't printing reduction steps"),
+      (":steps off", "Don't print reduction steps"),
     ];
 
     let max_name_length = ALL_COMMANDS.iter().map(|(name, _)| (*name).len()).max().unwrap_or(1);

--- a/src/lambda.lalrpop
+++ b/src/lambda.lalrpop
@@ -44,7 +44,7 @@ AssignLambdaIdentifier: &'input str = {
   },
 }
 
-EvalExpression: ExprRef<'eval> = {
+pub EvalExpression: ExprRef<'eval> = {
   "(" <EvalExpression> ")",
   <o:@L> <t:Identifier> => sym.build_eval_term(t, o.into()),
   "\\" <is:EvalLambdaIdentifier+> "." <e:EvalExpression> => sym.build_eval_lambda(is, e),

--- a/src/symbol_table.rs
+++ b/src/symbol_table.rs
@@ -3,12 +3,7 @@ use crossterm::style::Stylize;
 use itertools::Itertools;
 use lalrpop_util::{ErrorRecovery, lexer::Token};
 use num_traits::Num;
-use std::{
-  borrow::Cow,
-  collections::{BTreeMap, HashMap},
-  fmt,
-  num::NonZero,
-};
+use std::{borrow::Cow, collections::BTreeMap, fmt, num::NonZero};
 
 /// - Assigning an expression keeps results allocated permanently.
 /// - Evaluating an expression only computes results then clears allocations.
@@ -19,7 +14,7 @@ where
   assign_allocator: &'assign Allocator,
   eval_allocator: &'eval Allocator,
 
-  globals: &'globals mut HashMap<&'assign str, ExprRef<'assign>>,
+  globals: &'globals mut BTreeMap<&'assign str, ExprRef<'assign>>,
   numbers: &'numbers mut Vec<ExprRef<'assign>>,
   assign_scopes: Vec<&'assign str>,
   eval_scopes: Vec<&'eval str>,
@@ -31,7 +26,7 @@ impl<'assign, 'eval, 'globals, 'numbers> SymbolTable<'assign, 'eval, 'globals, '
   pub fn new(
     assign_allocator: &'assign Allocator,
     eval_allocator: &'eval Allocator,
-    globals: &'globals mut HashMap<&'assign str, ExprRef<'assign>>,
+    globals: &'globals mut BTreeMap<&'assign str, ExprRef<'assign>>,
     numbers: &'numbers mut Vec<ExprRef<'assign>>,
   ) -> Self {
     Self {


### PR DESCRIPTION
REPL mode has a bunch of built-in commands to simplify execution:

- `:all` - Print all named variables
- `:exit` - Exit the REPL
- `:help` - Print the help message
- `:load <file>` - Load and run a code file
- `:print <expr>` - Print an expression without evaluating it
- `:steps on` - Print reduction steps to stderr
- `:steps off` - Don't print reduction steps

**Other features:**

- Pressing `Ctrl+C` cancels evaluating an expression
- Pressing `Ctrl+D` exits the program
  - Pressing `Ctrl+C` twice in succession also exists the program
